### PR TITLE
Deduplicate instances of indexed map pattern

### DIFF
--- a/src/Globals.v3
+++ b/src/Globals.v3
@@ -1,31 +1,14 @@
 component Globals {
-	// Globals cannot be deleted in cicero
-	private def values: Vector<Object> = Vector.new(); // holds all the values and grows as new globals are added
-	private def indices: HashMap<string, int> = Strings.newMap(); // holds a mapping of global variable names and its index in values
+	def globals: FastMap<string, Object> = FastMaps.newStringMap();
 
-	// Returns the index of the stored global object in the `Globals.values` vector
-	def storeGlobal(id:string, v: Object) -> int {
-		var index: int;
-		if (indices.has(id)){
-			index = indices[id];
-			values[index] = v;
-		} else {
-			index = values.length;
-			indices[id] = index;
-			values.put(v);
-		}
-		return index;
+	def storeGlobal(id: string, v: Object) -> int {
+		return globals.storeKey(id, v);
 	}
 
-	// if valid lookup -> returns the `Object` 
-	// as well as its index in the `Globals.values` vector for bytecode rewriting purposes
 	def loadGlobal(id: string) -> Maybe<(Object, int)> {
-		if (indices.has(id)){
-			def index = indices[id];
-			def v = values[index];
-			return Maybe.Just((v, index));
-		} else {
-			return Maybe.Nothing;
+		match (globals.loadKey(id)) {
+			Just(obj) => return Maybe.Just((obj, globals.getIndex(id).fromJust()));
+			Nothing => return Maybe.Nothing;
 		}
 	}
 
@@ -33,12 +16,11 @@ component Globals {
 	 * Optimized functions that bypass the map lookup for globals
 	 * Used by `LOAD_GLOBAL_BY_INDEX` and `STORE_GLOBAL_BY_INDEX` opcodes
 	*/
-
 	def storeGlobalByIndex(index: int, v: Object) {
-		values[index] = v;
+		globals.storeIndex(index, v);
 	}
 
 	def loadGlobalByIndex(index: int) -> Object {
-		return values[index];
+		return globals.loadIndex(index);
 	}
 }

--- a/src/Object.v3
+++ b/src/Object.v3
@@ -46,8 +46,7 @@
  */
 class Object {
 	private var cls: ClassObject;
-	private def fieldMap: HashMap<string, int> = Strings.newMap();
-	private var fields:   Array<Object>;
+	private def fields: FastMap<string, Object> = FastMaps.newStringMap();
 
 	new() {}
 
@@ -96,19 +95,15 @@ class Object {
 			classes.put(clazz);
 		}
 		/* Figure out how much space needs to be allocated for fields. */
-		var i = 0;
 		for (clazz in classes.reverse().copy()) {
 			for (field in clazz.classFields) {
-				if (!fieldMap.has(field.0))
-					fieldMap[field.0] = i++;
+				fields.storeKey(field.0, null);
 			}
 			// methods are not initialized but a slot is allocated
 			for (method in clazz.classMethods) {
-				if (!fieldMap.has(method.id))
-					fieldMap[method.id] = i++;
+				fields.storeKey(method.id, null);
 			}
 		}
-		fields = Array.new(i);
 		/* Initialization sets classes, allocates space for fields, and
 		 * initializes methods. Setting the fields are done later. 
 		 * Non-method fields
@@ -123,7 +118,7 @@ class Object {
 			for (clazz in classes.copy()) {
 				for (func in clazz.classMethods) {
 					def m = MethodObject.new(this, func.id, func.params, func.code);
-					fields[fieldMap[func.id]] = m;
+					fields.storeKey(func.id, m);
 				}
 			}
 		}
@@ -134,37 +129,25 @@ class Object {
 	def setField(name: string, obj: Object) -> bool {
 		if (cls == null) initClass();
 
-		if (!fieldMap.has(name)) return false;
-		fields[fieldMap[name]] = obj;
+		if (!fields.hasKey(name)) return false;
+		fields.storeKey(name, obj);
 		return true;
 	}
 
  	def setFieldByIndex(idx: int, obj: Object) {
- 		fields[idx] = obj;
+		fields.storeIndex(idx, obj);
  	}
  
  	def getFieldByIndex(idx: int) -> Object {
 		if (CiceroOptions.sanityChecks) {
 			if (cls == null)
 				System.error("field error", "class not initialized");
-			if (idx < 0 || idx >= fields.length) {
-				System.error("field error", Strings.format3("field index %d is out of bounds for class %s (length %d)",
-							idx, cls.name, fields.length));
-			}
-			if (fields[idx] == null) {
-				System.error("field error", Strings.format2("access of field index %d for class %s is null",
-							idx, cls.name));
-			}
 		}
- 		return fields[idx];
+ 		return Assert.assertNonNull(fields.loadIndex(idx));
  	}
 
  	def getIndex(field: string) -> int {
-		if (fieldMap.has(field)) {
-			return fieldMap[field];
-		}
-		System.error("object error", Strings.format1("getting index of field not present: %s", field));
-		return -999;
+		return fields.getIndex(field).fromJust();
  	}
 
 	// returns null on failure
@@ -172,9 +155,9 @@ class Object {
 		if (cls == null) initClass();
 
 		// not a field of this class
-		if (!fieldMap.has(name)) return null;
+		if (!fields.hasKey(name)) return null;
 
-		def obj = fields[fieldMap[name]];
+		def obj = fields.loadKey(name).fromJust();
 		if (obj != null) return obj; // allocated
 	
 		if (CiceroOptions.useLazyMethods) {
@@ -183,7 +166,7 @@ class Object {
 				for (func in clazz.classMethods) {
 					if (Strings.equal(func.id, name)) {
 						def m = MethodObject.new(this, func.id, func.params, func.code);
-						fields[fieldMap[name]] = m;
+						fields.storeKey(name, m);
 						return m;
 					}
 				}
@@ -222,7 +205,7 @@ class Object {
 	}
 	def o_fields() -> Result {
 		def list = ListObject.new();
-		def fList = Maps.keyList(fieldMap);
+		def fList = fields.keyList();
 		Lists.apply(fList, putList(list, _));
 		return Result.OK(list);
 	}

--- a/src/util/Assert.v3
+++ b/src/util/Assert.v3
@@ -2,6 +2,14 @@ component Assert {
 	def assert(b: bool) {
 		if (!b) System.error("assertion error", "failed assertion");
 	}
+	def assertNonNull(v: Object) -> Object {
+		if (CiceroOptions.sanityChecks) {
+			if (v == null) {
+				System.error("assertion error", "null value");
+			}
+		}
+		return v;
+	}
 	def assertArity(argv: Array<Object>, argc: int) {
 		assert(argv.length == argc);
 	}

--- a/src/util/FastMap.v3
+++ b/src/util/FastMap.v3
@@ -33,14 +33,22 @@ class FastMap<K, V>(hash: K -> int, equals: (K, K) -> bool) {
 		return values[idx];
 	}
 
+	def hasKey(key: K) -> bool {
+		return indices.has(key);
+	}
+
 	def getIndex(key: K) -> Maybe<int> {
-		if (indices.has(key)){
+		if (indices.has(key)) {
 			def idx = indices[key];
 			def val = values[idx];
 			return Maybe.Just(idx);
 		} else {
 			return Maybe.Nothing;
 		}
+	}
+
+	def keyList() -> List<K> {
+		return Maps.keyList(indices);
 	}
 
 	def each(f: (int, V) -> void) {

--- a/src/util/FastMap.v3
+++ b/src/util/FastMap.v3
@@ -1,0 +1,57 @@
+// A HashMap that allows for indexed access based on insertion order.
+// NOTE: the map does *not* allow for removing entries
+class FastMap<K, V>(hash: K -> int, equals: (K, K) -> bool) {
+	private def values: Vector<V> = Vector.new();
+	private def indices: HashMap<K, int> = HashMap.new(hash, equals);
+
+	def storeKey(key: K, val: V) -> int {
+		var idx: int;
+		if (indices.has(key)){
+			idx = indices[key];
+			values[idx] = val;
+		} else {
+			idx = values.length;
+			indices[key] = idx;
+			values.put(val);
+		}
+		return idx;
+	}
+	def storeIndex(idx: int, val: V) {
+		values[idx] = val;
+	}
+
+	def loadKey(key: K) -> Maybe<V> {
+		if (indices.has(key)){
+			def idx = indices[key];
+			def val = values[idx];
+			return Maybe.Just(val);
+		} else {
+			return Maybe.Nothing;
+		}
+	}
+	def loadIndex(idx: int) -> V { // XXX, assume you have a value index
+		return values[idx];
+	}
+
+	def getIndex(key: K) -> Maybe<int> {
+		if (indices.has(key)){
+			def idx = indices[key];
+			def val = values[idx];
+			return Maybe.Just(idx);
+		} else {
+			return Maybe.Nothing;
+		}
+	}
+
+	def each(f: (int, V) -> void) {
+		for (i < values.length) {
+			f(i, values[i]);
+		}
+	}
+}
+
+component FastMaps {
+	def newStringMap<V>() -> FastMap<string, V> {
+		return FastMap.new(Strings.hash, Strings.equal);
+	}
+}


### PR DESCRIPTION
There are now two (but in my mind more in the future) instances of a map where values can be accessed by the key, but also by an index which is allocated when the key-value pair is first inserted into the map:

- [X] globals
- [x] fields
- [ ] (future, #18) methods

These are refactored into `src/util/FastMap.v3`. Essentially, we are adding the ability to perform constant-time accesses on map accesses when we know where the key is allocated, at the cost of an extra layer of indirection when doing a key access.